### PR TITLE
演習3-3（外国語レッスンのマッチングサービス4週目）

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,19 @@
  *= require_tree .
  *= require_self
  */
+
+table, td, th {
+  border: 1px solid;
+  }
+
+.high{
+  background-color: red;
+  }
+
+.middle{
+  background-color: pink;
+  }
+
+.low{
+  background-color: mediumturquoise;
+  }

--- a/app/controllers/admins/language_reservation_rates_controller.rb
+++ b/app/controllers/admins/language_reservation_rates_controller.rb
@@ -1,0 +1,5 @@
+class Admins::LanguageReservationRatesController < Admins::ApplicationController
+  def show
+    @language = Language.find(params[:language])
+  end
+end

--- a/app/controllers/admins/languages_controller.rb
+++ b/app/controllers/admins/languages_controller.rb
@@ -1,0 +1,5 @@
+class Admins::LanguagesController < Admins::ApplicationController
+  def index
+    @languages = Language.all.page(params[:page])
+  end
+end

--- a/app/controllers/admins/teacher_reservation_rates_controller.rb
+++ b/app/controllers/admins/teacher_reservation_rates_controller.rb
@@ -1,0 +1,5 @@
+class Admins::TeacherReservationRatesController < Admins::ApplicationController
+  def show
+    @teacher = Teacher.find(params[:teacher])  
+  end
+end

--- a/app/controllers/admins/teacher_reservation_rates_controller.rb
+++ b/app/controllers/admins/teacher_reservation_rates_controller.rb
@@ -1,5 +1,5 @@
 class Admins::TeacherReservationRatesController < Admins::ApplicationController
   def show
-    @teacher = Teacher.find(params[:teacher])  
+    @teacher = Teacher.find(params[:teacher])
   end
 end

--- a/app/controllers/admins/time_reservation_rates_controller.rb
+++ b/app/controllers/admins/time_reservation_rates_controller.rb
@@ -1,0 +1,4 @@
+class Admins::TimeReservationRatesController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/admins/time_reservation_rates_controller.rb
+++ b/app/controllers/admins/time_reservation_rates_controller.rb
@@ -1,4 +1,4 @@
-class Admins::TimeReservationRatesController < ApplicationController
+class Admins::TimeReservationRatesController < Admins::ApplicationController
   def show
   end
 end

--- a/app/controllers/teachers/multiple_lessons_controller.rb
+++ b/app/controllers/teachers/multiple_lessons_controller.rb
@@ -5,7 +5,7 @@ class Teachers::MultipleLessonsController < Teachers::ApplicationController
   end
 
   def create
-    started_at_ary = params[:time_range][:started_at].without("")
+    started_at_ary = params[:time_range][:started_at].without('')
     if started_at_ary.present?
       started_at_ary.each do |started_at|
         current_teacher.lessons.create!(started_at: started_at)
@@ -18,9 +18,7 @@ class Teachers::MultipleLessonsController < Teachers::ApplicationController
 
   private
 
-  def wrap_in_transaction
-    ActiveRecord::Base.transaction do
-      yield
-    end
+  def wrap_in_transaction(&block)
+    ActiveRecord::Base.transaction(&block)
   end
 end

--- a/app/controllers/teachers/multiple_lessons_controller.rb
+++ b/app/controllers/teachers/multiple_lessons_controller.rb
@@ -1,0 +1,26 @@
+class Teachers::MultipleLessonsController < Teachers::ApplicationController
+  around_action :wrap_in_transaction, only: [:create]
+
+  def new
+  end
+
+  def create
+    started_at_ary = params[:time_range][:started_at].without("")
+    if started_at_ary.present?
+      started_at_ary.each do |started_at|
+        current_teacher.lessons.create!(started_at: started_at)
+      end
+      redirect_to teachers_lessons_path, notice: 'レッスンを作成しました'
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def wrap_in_transaction
+    ActiveRecord::Base.transaction do
+      yield
+    end
+  end
+end

--- a/app/controllers/teachers/time_range_lessons_controller.rb
+++ b/app/controllers/teachers/time_range_lessons_controller.rb
@@ -1,0 +1,29 @@
+class Teachers::TimeRangeLessonsController < Teachers::ApplicationController
+  around_action :wrap_in_transaction, only: [:create]
+  
+  def new
+  end
+
+  def create
+    date = params[:date].in_time_zone
+    start_time = params[:start_time].to_i
+    end_time = params[:end_time].to_i
+    time_range = (start_time..end_time).to_a
+    if date.blank? || time_range.blank?
+      render :new
+    else
+      time_range.each do |time|
+        current_teacher.lessons.create!(started_at: date + time.hours)
+      end
+      redirect_to teachers_lessons_path, notice: 'レッスンを作成しました'
+    end
+  end
+
+  private
+
+  def wrap_in_transaction
+    ActiveRecord::Base.transaction do
+      yield
+    end    
+  end
+end

--- a/app/controllers/teachers/time_range_lessons_controller.rb
+++ b/app/controllers/teachers/time_range_lessons_controller.rb
@@ -1,6 +1,6 @@
 class Teachers::TimeRangeLessonsController < Teachers::ApplicationController
   around_action :wrap_in_transaction, only: [:create]
-  
+
   def new
   end
 
@@ -21,9 +21,7 @@ class Teachers::TimeRangeLessonsController < Teachers::ApplicationController
 
   private
 
-  def wrap_in_transaction
-    ActiveRecord::Base.transaction do
-      yield
-    end    
+  def wrap_in_transaction(&block)
+    ActiveRecord::Base.transaction(&block)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,6 +23,10 @@ module ApplicationHelper
     %w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日].freeze
   end
 
+  def time_range
+    (7..22).to_a
+  end
+
   def reservation_rate(lessons)
     teacher_lessons = lessons
     reserved_teacher_lessons = teacher_lessons.reserved

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,11 +12,11 @@ module ApplicationHelper
   end
 
   def dates_in_this_month
-    (today.beginning_of_month..today.end_of_month).to_a
+    today.all_month.to_a
   end
 
   def weeks_in_this_month
-    dates_in_this_month.slice_before {|date| date.wday.zero?}.to_a
+    dates_in_this_month.slice_before { |date| date.wday.zero? }.to_a
   end
 
   def days_of_week

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,31 @@ module ApplicationHelper
   def languages_option
     Language.all.map { |language| [ja(language.name), language.id] }
   end
+
+  def today
+    Date.current
+  end
+
+  def dates_in_this_month
+    (today.beginning_of_month..today.end_of_month).to_a
+  end
+
+  def weeks_in_this_month
+    dates_in_this_month.slice_before {|date| date.wday.zero?}.to_a
+  end
+
+  def days_of_week
+    %w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日].freeze
+  end
+
+  def reservation_rate(lessons)
+    teacher_lessons = lessons
+    reserved_teacher_lessons = teacher_lessons.reserved
+    if teacher_lessons.count.zero?
+      '--'
+    else
+      reservation_rate = reserved_teacher_lessons.count / teacher_lessons.count.to_f * 100
+      reservation_rate.to_i
+    end
+  end
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -17,7 +17,8 @@ class Lesson < ApplicationRecord
   scope :for_month, -> (date) { where(started_at: date.in_time_zone.all_month)}
   scope :for_day, -> (date) { where(started_at: date.in_time_zone.all_day)}
   scope :for_language, -> (language) { where(teacher_id: language.teachers)}
-
+  scope :for_time, -> (datetime) {where('? <= started_at AND started_at <= ?', datetime.in_time_zone.beginning_of_hour, datetime.in_time_zone.end_of_hour)}
+  
   def started_at_should_not_be_past
     errors.add(:started_at, 'は現在以降の日時を指定してください') if self.started_at.past?
   end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -14,11 +14,11 @@ class Lesson < ApplicationRecord
   scope :search_by_date, ->(date) { where(started_at: date.in_time_zone.all_day) }
   scope :asc, -> { order('started_at ASC') }
   scope :desc, -> { order('started_at DESC') }
-  scope :for_month, -> (date) { where(started_at: date.in_time_zone.all_month)}
-  scope :for_day, -> (date) { where(started_at: date.in_time_zone.all_day)}
-  scope :for_language, -> (language) { where(teacher_id: language.teachers)}
-  scope :for_time, -> (datetime) {where('? <= started_at AND started_at <= ?', datetime.in_time_zone.beginning_of_hour, datetime.in_time_zone.end_of_hour)}
-  
+  scope :for_month, ->(date) { where(started_at: date.in_time_zone.all_month) }
+  scope :for_day, ->(date) { where(started_at: date.in_time_zone.all_day) }
+  scope :for_language, ->(language) { where(teacher_id: language.teachers) }
+  scope :for_time, ->(datetime) { where('? <= started_at AND started_at <= ?', datetime.in_time_zone.beginning_of_hour, datetime.in_time_zone.end_of_hour) }
+
   def started_at_should_not_be_past
     errors.add(:started_at, 'は現在以降の日時を指定してください') if self.started_at.past?
   end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -14,6 +14,9 @@ class Lesson < ApplicationRecord
   scope :search_by_date, ->(date) { where(started_at: date.in_time_zone.all_day) }
   scope :asc, -> { order('started_at ASC') }
   scope :desc, -> { order('started_at DESC') }
+  scope :for_month, -> (date) { where(started_at: date.in_time_zone.all_month)}
+  scope :for_day, -> (date) { where(started_at: date.in_time_zone.all_day)}
+  scope :for_language, -> (language) { where(teacher_id: language.teachers)}
 
   def started_at_should_not_be_past
     errors.add(:started_at, 'は現在以降の日時を指定してください') if self.started_at.past?

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -4,7 +4,7 @@ class Student < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :purchase_tickets, dependent: :destroy
-  has_many :valid_purchase_tickets, -> { where(deadline: Date.current..) }, class_name: 'PurchaseTicket'
+  has_many :valid_purchase_tickets, -> { where(deadline: Date.current..) }, class_name: 'PurchaseTicket', dependent: :destroy
   has_many :tickets, through: :purchase_tickets, source: :ticket
   has_many :lesson_reservations, dependent: :destroy
   has_many :lessons, through: :lesson_reservations, source: :lesson

--- a/app/views/admins/language_reservation_rates/show.html.haml
+++ b/app/views/admins/language_reservation_rates/show.html.haml
@@ -1,0 +1,15 @@
+%h2= ja(@language.name)
+%p #{today.month}月の予約率: #{reservation_rate(Lesson.for_language(@language).for_month(today))}%
+%p ※測定不能の場合「--」と表示
+%table
+  - days_of_week.each do |day|
+    %th= day
+  - weeks_in_this_month.each do |week|
+    %tr
+      - week.each do |date|
+        - if date == today.beginning_of_month
+          - date.wday.times do
+            %td
+        %td
+          %p= date.day
+          %p #{reservation_rate(Lesson.for_language(@language).for_day(date))}%

--- a/app/views/admins/languages/index.html.haml
+++ b/app/views/admins/languages/index.html.haml
@@ -1,0 +1,6 @@
+%h2 言語一覧画面
+- @languages.each do |language|
+  %p
+    = ja(language.name)
+    = link_to '予約率表', admins_language_reservation_rate_path(language: language)
+= paginate @languages

--- a/app/views/admins/show.html.haml
+++ b/app/views/admins/show.html.haml
@@ -1,2 +1,4 @@
 %h2 マイページ
-= link_to '講師一覧', admins_teachers_path
+%p= link_to '時間別予約率表', admins_time_reservation_rate_path
+%p= link_to '講師一覧', admins_teachers_path
+%p= link_to '言語一覧', admins_languages_path

--- a/app/views/admins/teacher_reservation_rates/show.html.haml
+++ b/app/views/admins/teacher_reservation_rates/show.html.haml
@@ -1,0 +1,15 @@
+%h2 #{@teacher.name}さん
+%p #{today.month}月の予約率: #{reservation_rate(@teacher.lessons.for_month(today))}%
+%p ※測定不能の場合「--」と表示
+%table
+  - days_of_week.each do |day|
+    %th= day
+  - weeks_in_this_month.each do |week|
+    %tr
+      - week.each do |date|
+        - if date == today.beginning_of_month
+          - date.wday.times do
+            %td
+        %td
+          %p= date.day
+          %p #{reservation_rate(@teacher.lessons.for_day(date))}%

--- a/app/views/admins/teachers/index.html.haml
+++ b/app/views/admins/teachers/index.html.haml
@@ -1,7 +1,8 @@
 %h2 講師一覧画面
 - @teachers.each do |teacher|
   %p
-    = teacher.email
+    = teacher.name
+    = link_to '予約率表', admins_teacher_reservation_rate_path(teacher: teacher)
     = link_to '代理ログイン', admins_sign_in_as_a_teacher_path(teacher: teacher), method: :post
     = link_to '削除', admins_teacher_path(teacher), method: :delete
 = link_to '講師作成', new_admins_teacher_path

--- a/app/views/admins/time_reservation_rates/show.html.haml
+++ b/app/views/admins/time_reservation_rates/show.html.haml
@@ -1,2 +1,22 @@
-%h1 Admins::TimeReservationRates#show
-%p Find me in app/views/admins/time_reservation_rates/show.html.haml
+%h2 #{today.month}月の時間別予約率表
+%p ※赤色 → 予約率86%以上
+%p ※桃色 → 予約率51〜85%
+%p ※青色 → 予約率50%以下
+%p ※レッスンの予定がない場合"--"
+%table
+  %th
+  - dates_in_this_month.each do |date|
+    %th= date.day
+  - time_range.each do |time|
+    %tr
+      %td= time
+      - dates_in_this_month.each do |date|
+        - time_reservation_rate = reservation_rate(Lesson.for_time(date.in_time_zone + time.hours))
+        -if time_reservation_rate == '--'
+          %td= time_reservation_rate
+        - elsif time_reservation_rate >= 86
+          %td.high= time_reservation_rate
+        - elsif time_reservation_rate <= 50 
+          %td.low= time_reservation_rate
+        - else
+          %td.middle= time_reservation_rate

--- a/app/views/admins/time_reservation_rates/show.html.haml
+++ b/app/views/admins/time_reservation_rates/show.html.haml
@@ -1,0 +1,2 @@
+%h1 Admins::TimeReservationRates#show
+%p Find me in app/views/admins/time_reservation_rates/show.html.haml

--- a/app/views/teachers/lessons/new.html.haml
+++ b/app/views/teachers/lessons/new.html.haml
@@ -7,3 +7,5 @@
 = form_with(model: @lesson, url: teachers_lessons_path) do |f|
   %p= f.datetime_field :started_at, min: Date.current
   %p= f.submit
+%p= link_to '複数レッスンを同時作成する' ,new_teachers_multiple_lesson_path
+%p= link_to '時間指定でレッスンを一括作成する' ,new_teachers_time_range_lesson_path

--- a/app/views/teachers/multiple_lessons/new.html.haml
+++ b/app/views/teachers/multiple_lessons/new.html.haml
@@ -1,0 +1,5 @@
+%h2 レッスン複数作成画面
+= form_with(url: teachers_multiple_lessons_path) do |f|
+  - 3.times do
+    = f.datetime_field 'time_range[started_at][]', min: Date.current
+  = f.submit

--- a/app/views/teachers/time_range_lessons/new.html.haml
+++ b/app/views/teachers/time_range_lessons/new.html.haml
@@ -1,0 +1,11 @@
+%h2 レッスン時間指定作成画面
+%p 作成日時を選択してください
+- time_range = (7..22).to_a
+= form_with(url: teachers_time_range_lessons_path) do |f|
+  %p
+    = f.date_field :date, min: Date.current
+    = f.select :start_time, time_range
+    時〜
+    = f.select :end_time, time_range
+    時
+    = f.submit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,8 @@ Rails.application.routes.draw do
     resources :reserved_lessons, only: %i[index show]
     resources :past_lessons, only: %i[index show]
     resources :student_past_lessons, only: %i[index show]
+    resources :multiple_lessons, only: %i[new create]
+    resources :time_range_lessons, only: %i[new create]
     resources :reviews, only: %i[new create show edit update destroy]
   end
   resource :admin, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,10 @@ Rails.application.routes.draw do
   resource :top, only: [:show]
   namespace :admins do
     resources :teachers, only: %i[index new create destroy]
+    resources :languages, only: [:index]
+    resource :time_reservation_rate, only: [:show]
+    resource :teacher_reservation_rate, only: [:show]
+    resource :language_reservation_rate, only: [:show]
   end
   namespace :students do
     resources :purchase_tickets, only: %i[new create]

--- a/db/migrate/20210830041215_change_default_on_purchase_ticket.rb
+++ b/db/migrate/20210830041215_change_default_on_purchase_ticket.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultOnPurchaseTicket < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :purchase_tickets, :deadline, from: Date.current.since(1000.years), to: Float::INFINITY 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_29_163015) do
+ActiveRecord::Schema.define(version: 2021_08_30_041215) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 2021_08_29_163015) do
   create_table "purchase_tickets", force: :cascade do |t|
     t.bigint "ticket_id", null: false
     t.bigint "student_id", null: false
-    t.date "deadline", default: "3021-08-29", null: false
+    t.date "deadline", default: "Infinity", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["student_id"], name: "index_purchase_tickets_on_student_id"


### PR DESCRIPTION
## 概要
レッスンフィードバックの実装により、ユーザー向けのサービスが大きく充実しました。一方で、ユーザーからは予約がしにくいというクレームを受けるようになってきました。時間帯や講師、レッスン言語によって、レッスン枠を空けても予約がされなかったり、逆に予約が過密しすぎてしまう状況があるためです。運営チームはこの事態を解決するために、予約データから以下のような情報を参照できるように管理機能を充実させようとしています。

## 要件
どの時間帯に一番予約が集中しているか見える化したい
日付を縦列、時刻を横軸として、それぞれ交差する日時の予約率（予約数 / レッスン枠数）を表示する
50%以下は青、51〜85%は薄赤、86%〜は赤でマスを表示する

講師毎の予約率を見える化したい
月毎の講師別予約率を参照できるようにする
詳細として、日毎の予約率も参照できるようにする
曜日による違いも見たいため、曜日情報も表示すること
言語別の予約率を見える化したい

月毎の言語別予約率を参照できるようにする
詳細として、日毎の予約率も参照できるようにする
曜日による違いも見たいため、曜日情報も表示すること

また、サービスの人気に伴い、講師のレッスン登録のしやすさも重要になりました。以下の機能を実装してレッスン登録をスムーズにしましょう。
日時の範囲指定でレッスン枠を一括で登録できるように
日時の複数指定でレッスン枠を一括で登録できるように

## 注意事項
時間別予約表に関して、「表示する日にち範囲はフォームで指定できるようにする」は実装していません
せっかくhelper等で綺麗にしたので、parameterを受け取って表示を変える処理をかくとなるとごちゃごちゃしてしまうと思ったこと、そこまでして必要な機能と思わなかったことが未実装の理由です
※もしやった方が良いということであれば後々実装します🐷
