### PR TITLE
演習3-4（外国語レッスンのマッチングサービス4週目）

### DIFF
--- a/app/controllers/students/choice_monthly_plans_controller.rb
+++ b/app/controllers/students/choice_monthly_plans_controller.rb
@@ -1,6 +1,6 @@
 class Students::ChoiceMonthlyPlansController < Students::ApplicationController
   before_action :set_choice_monthly_plan, only: %i[show edit update destroy]
-  
+
   def new
     @choice_monthly_plan = current_student.build_choice_monthly_plan
   end

--- a/app/controllers/students/choice_monthly_plans_controller.rb
+++ b/app/controllers/students/choice_monthly_plans_controller.rb
@@ -1,0 +1,45 @@
+class Students::ChoiceMonthlyPlansController < Students::ApplicationController
+  before_action :set_choice_monthly_plan, only: %i[show edit update destroy]
+  
+  def new
+    @choice_monthly_plan = current_student.build_choice_monthly_plan
+  end
+
+  def create
+    @choice_monthly_plan = current_student.build_choice_monthly_plan(choice_monthly_plan_params)
+    if @choice_monthly_plan.save
+      redirect_to student_path(current_student), notice: '月額定期プランに加入しました'
+    else
+      render :new
+    end
+  end
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+    if @choice_monthly_plan.update(choice_monthly_plan_params)
+      redirect_to student_path(current_student), notice: '月額定期プランを変更しました'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @choice_monthly_plan.destroy!
+    redirect_to student_path(current_student), notice: '月額定期プランを休止しました'
+  end
+
+  private
+
+  def choice_monthly_plan_params
+    params.require(:choice_monthly_plan).permit %i[student_id monthly_plan_id]
+  end
+
+  def set_choice_monthly_plan
+    @choice_monthly_plan = current_student.choice_monthly_plan
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,6 +7,14 @@ module ApplicationHelper
     Language.all.map { |language| [ja(language.name), language.id] }
   end
 
+  def tickets_option
+    Ticket.where(fee: [2200, 5500, 8250]).map { |ticket| ["#{ticket.fee}円 レッスン可能数: #{ticket.lesson_count}", ticket.id] }
+  end
+
+  def monthly_plans_option
+    MonthlyPlan.pluck(:name, :id)
+  end
+
   def today
     Date.current
   end

--- a/app/models/choice_monthly_plan.rb
+++ b/app/models/choice_monthly_plan.rb
@@ -5,7 +5,7 @@ class ChoiceMonthlyPlan < ApplicationRecord
   validates :student_id, uniqueness: { scope: :monthly_plan_id }
 
   def self.ticket_subscription
-    self.all.each do |choice_monthly_plan|
+    self.all.find_each do |choice_monthly_plan|
       choice_monthly_plan.student.purchase_tickets.create!(ticket_id: choice_monthly_plan.monthly_plan.ticket.id, deadline: Date.current.end_of_month)
     end
   end

--- a/app/models/choice_monthly_plan.rb
+++ b/app/models/choice_monthly_plan.rb
@@ -1,0 +1,6 @@
+class ChoiceMonthlyPlan < ApplicationRecord
+  belongs_to :student
+  belongs_to :monthly_plan
+  validates :monthly_plan, presence: true
+  validates :student_id, uniqueness: { scope: :monthly_plan_id }
+end

--- a/app/models/choice_monthly_plan.rb
+++ b/app/models/choice_monthly_plan.rb
@@ -3,4 +3,10 @@ class ChoiceMonthlyPlan < ApplicationRecord
   belongs_to :monthly_plan
   validates :monthly_plan, presence: true
   validates :student_id, uniqueness: { scope: :monthly_plan_id }
+
+  def self.ticket_subscription
+    self.all.each do |choice_monthly_plan|
+      choice_monthly_plan.student.purchase_tickets.create!(ticket_id: choice_monthly_plan.monthly_plan.ticket.id, deadline: Date.current.end_of_month)
+    end
+  end
 end

--- a/app/models/monthly_plan.rb
+++ b/app/models/monthly_plan.rb
@@ -1,3 +1,4 @@
 class MonthlyPlan < ApplicationRecord
   belongs_to :ticket
+  has_many :choice_monthly_plans, dependent: :destroy
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -5,9 +5,10 @@ class Student < ApplicationRecord
          :recoverable, :rememberable, :validatable
   has_many :purchase_tickets, dependent: :destroy
   has_many :valid_purchase_tickets, -> { where(deadline: Date.current..) }, class_name: 'PurchaseTicket', dependent: :destroy
-  has_many :tickets, through: :purchase_tickets, source: :ticket
+  has_many :tickets, through: :valid_purchase_tickets, source: :ticket
   has_many :lesson_reservations, dependent: :destroy
   has_many :lessons, through: :lesson_reservations, source: :lesson
+  has_one :choice_monthly_plan, dependent: :destroy
 
   def remaining_lesson_count
     lesson_count = self.tickets.sum(:lesson_count)

--- a/app/views/students/choice_monthly_plans/edit.html.haml
+++ b/app/views/students/choice_monthly_plans/edit.html.haml
@@ -1,0 +1,5 @@
+%h2 定期プラン変更画面
+%p ※加入月の翌月からサービスをご利用いただけます
+= form_with(model: @choice_monthly_plan, url: students_choice_monthly_plan_path, method: :put) do |f|
+  = f.select :monthly_plan_id, monthly_plans_option
+  = f.submit

--- a/app/views/students/choice_monthly_plans/new.html.haml
+++ b/app/views/students/choice_monthly_plans/new.html.haml
@@ -1,0 +1,5 @@
+%h2 定期プラン選択画面
+%p ※加入月の翌月からサービスをご利用いただけます
+= form_with(model: @choice_monthly_plan, url: students_choice_monthly_plans_path) do |f|
+  = f.select :monthly_plan_id, monthly_plans_option
+  = f.submit

--- a/app/views/students/choice_monthly_plans/show.html.haml
+++ b/app/views/students/choice_monthly_plans/show.html.haml
@@ -1,0 +1,5 @@
+%h2 定期プラン内容
+%p= @choice_monthly_plan.monthly_plan.name
+%p ※毎月#{@choice_monthly_plan.monthly_plan.ticket.lesson_count}回レッスンを受講することができます
+%p= link_to 'プラン変更', edit_students_choice_monthly_plan_path
+%p= link_to 'プランを休止する', students_choice_monthly_plan_path, method: :delete

--- a/app/views/students/purchase_tickets/new.html.haml
+++ b/app/views/students/purchase_tickets/new.html.haml
@@ -1,5 +1,4 @@
 %h2 チケット購入画面
-- tickets_option = Ticket.where(fee: [2200, 5500, 8250]).map { |ticket| ["#{ticket.fee}円 レッスン可能数: #{ticket.lesson_count}", ticket.id] }
 = form_with(model: @purchase_ticket, url: students_purchase_tickets_path) do |f|
   = f.select :ticket_id, tickets_option, include_blank: '-選択してください-'
   = f.submit '購入する'

--- a/app/views/students/show.html.haml
+++ b/app/views/students/show.html.haml
@@ -4,3 +4,7 @@
 %p 予約可能数: #{@student.remaining_lesson_count}
 %p= link_to '編集', edit_student_registration_path
 %p= link_to 'チケット購入', new_students_purchase_ticket_path
+- if @student.choice_monthly_plan.present?
+  %p= link_to '加入済みプランを確認する', students_choice_monthly_plan_path(@student.choice_monthly_plan)
+-else
+  %p= link_to '定期プラン加入', new_students_choice_monthly_plan_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
     resources :reserved_lessons, only: %i[index show]
     resources :past_lessons, only: %i[index]
     resource :teacher_review, only: %i[show]
+    resources :choice_monthly_plans, only: %i[new create show edit update destroy]
   end
   namespace :teachers do
     resources :lessons

--- a/db/migrate/20210830143847_create_choice_monthly_plans.rb
+++ b/db/migrate/20210830143847_create_choice_monthly_plans.rb
@@ -1,0 +1,11 @@
+class CreateChoiceMonthlyPlans < ActiveRecord::Migration[6.1]
+  def change
+    create_table :choice_monthly_plans do |t|
+      t.references :student, null: false, foreign_key: true, index: false
+      t.references :monthly_plan, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :choice_monthly_plans, %i[student_id monthly_plan_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_30_041215) do
+ActiveRecord::Schema.define(version: 2021_08_30_143847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,15 @@ ActiveRecord::Schema.define(version: 2021_08_30_041215) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "choice_monthly_plans", force: :cascade do |t|
+    t.bigint "student_id", null: false
+    t.bigint "monthly_plan_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["monthly_plan_id"], name: "index_choice_monthly_plans_on_monthly_plan_id"
+    t.index ["student_id", "monthly_plan_id"], name: "index_choice_monthly_plans_on_student_id_and_monthly_plan_id", unique: true
   end
 
   create_table "languages", force: :cascade do |t|
@@ -118,6 +127,8 @@ ActiveRecord::Schema.define(version: 2021_08_30_041215) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "choice_monthly_plans", "monthly_plans"
+  add_foreign_key "choice_monthly_plans", "students"
   add_foreign_key "lesson_reservations", "lessons"
   add_foreign_key "lesson_reservations", "students"
   add_foreign_key "lessons", "teachers"

--- a/lib/tasks/monthly_task.rake
+++ b/lib/tasks/monthly_task.rake
@@ -1,0 +1,11 @@
+namespace :monthly_task do
+  desc '定期プランでチケットを購入する処理'
+
+  task ticket_subscription: :environment do
+    if Date.current == Date.current.beginning_of_month
+      ActiveRecord::Base.transaction do
+        ChoiceMonthlyPlan.ticket_subscription
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 課題4
## 概要
サブスクリプション型のサービスへ
サービス運営を続ける中、一部ユーザーからいちいちチケットを買うのが面倒くさいという声があがりはじめました。そこで個別にチケットを買う形から、定期決済の導入をしようと考えました。以下の機能を実装しましょう。

## 要件
定期決済プランを購入できるように
ライトプラン：毎月5回、月額7000円
スタンダードプラン：毎月7回、月額9500円
ヘビープラン：毎月10回、月額12000円
定期決済で追加されたチケットは追加日から30日以内のみ使えるように
補足：従来型の都度購入のチケットは無期限で使える
プラン変更を行うことができるように
旧プランのチケットは期限内であれば引き続き使えるように
プランを休止できるように
休止前のプランチケットが残っている場合は、期限内であれば引き続き使えるように

## 注意事項
下記に関して、相談の上要件から外しました
・定期決済の決済履歴を確認できるように
・定期決済で使用しているカード情報を変更できるように

herokuにはあげてませんが、herokuにあげた際にスケジューラで毎日rakeが実行される場合を想定して作りました
planを購入すると、毎月一日にシステム内で該当するチケット（期限一ヶ月間なのでその月内のみ有効）が購入される仕様となっています